### PR TITLE
actions: end game when done

### DIFF
--- a/src/game/actions.ts
+++ b/src/game/actions.ts
@@ -59,10 +59,10 @@ export const executeAction = <T extends ActionName>(
 };
 
 /**
- * Ends the turn for the current player.
+ * Ends the turn for the current player, or ends game for all if current player ended the game. 
  */
 export const DoneAction = (s: GameState) => {
-  if (!canEndTurn(s)) {
+  if (!canEndTurn(s) || s.isDone) {
     return s.context;
   }
 


### PR DESCRIPTION
If a player ends the game while still holding a marker and it wasn’t because they picked up the last marker, game should end without prompting them to place marker.